### PR TITLE
Change line endings in SMTP commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ module.exports = function (email, opts) {
       options.host = opts.host || options.from.split('@')[1];
       var step = 0;
       const COMM = [
-        'helo ' + options.host + '\n',
-        'mail from:<' + options.from + '>\n',
-        'rcpt to:<' + email + '>\n'
+        'helo ' + options.host + '\r\n',
+        'mail from:<' + options.from + '>\r\n',
+        'rcpt to:<' + email + '>\r\n'
       ];
       return new Promise(function (resolve, reject) {
         var socket = net.createConnection(25, address);


### PR DESCRIPTION
Change from `\n` to `\r\n` to coincide with the [spec](https://www.rfc-editor.org/rfc/rfc2821#section-2.3.7).

For example Microsoft Outlook exchange server doesn't respond if `\n` line endings are used instead of `\r\n`.